### PR TITLE
Fix `--no-colored-log` to properly disable ANSI color codes

### DIFF
--- a/baby_logger.py
+++ b/baby_logger.py
@@ -20,9 +20,17 @@ class LogLevel(Enum):
 
 
 class Logger():
-    def __init__(self, verbosity=LogLevel.ERROR, template="[{level} - {timestamp}]: {message}") -> None:
+    def __init__(self, verbosity=LogLevel.ERROR, template="[{level} - {timestamp}]: {message}", no_color=False) -> None:
         self.verbosity_level = verbosity
         self.template = template
+        self.no_color = no_color
+
+        if self.no_color:
+            self.disable_colors()
+        
+    def disable_colors(self):
+        global Fore, Style
+        Fore.RED = Fore.GREEN = Fore.BLUE = Fore.YELLOW = Fore.MAGENTA = Fore.WHITE = ""
 
     def log(self, level: LogLevel, message: str):
         if level.value <= self.verbosity_level.value:

--- a/main.py
+++ b/main.py
@@ -119,8 +119,11 @@ def main(args: list[str]) -> int:
         return 0
     
     if parsed_args.no_colored_log:
-        init(autoreset=False)
+        global Fore, Style
+        Fore.RED = Fore.GREEN = Fore.BLUE = Fore.YELLOW = Fore.MAGENTA = Fore.WHITE = ""
+        Style.BRIGHT = Style.RESET_ALL = ""
     
+    # There's no need to pass 'no_color', thanks to python cool import system!
     logger = Logger() # Default verbosity level is ERROR
 
     if parsed_args.verbose is not None:


### PR DESCRIPTION
This PR fixes the `--no-colored-log` flag, ensuring ANSI codes are properly disabled.  
Now, all color formatting is removed dynamically when the flag is set.